### PR TITLE
Remove lodash definitions from objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules
 lib
 coverage
+
+.idea/
+.vscode/
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,9 @@ function _Object<P extends Props, R extends boolean>(props: P, required: R) {
 
             const ret = {
                 type: 'object',
-                properties: _.mapValues(props, v => v.getJsonSchema()),
+                properties: _.mapValues(props, v =>
+                    v.getJsonSchema(),
+                ) as Record<string, any>,
                 additionalProperties: false,
             };
             return propsRequired.length > 0


### PR DESCRIPTION
Je ne pense pas que l'export des types lodash pour les objets soit volontaire, je ne sais pas si c'est la bonne manière de régler le problème mais il n'y a plus d'erreurs comme ça.