### PR TITLE
Fix TypeScript bug where missing parameters are inferred as "any" type

### DIFF
--- a/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/__tests__/__snapshots__/index.test.ts.snap
@@ -311,6 +311,27 @@ Object {
 }
 `;
 
+exports[`typed-ajv Object() works with object schema and nested array 1`] = `
+Object {
+  "additionalProperties": false,
+  "properties": Object {
+    "a": Object {
+      "items": Object {
+        "transform": Array [
+          "trim",
+        ],
+        "type": "string",
+      },
+      "type": "array",
+    },
+  },
+  "required": Array [
+    "a",
+  ],
+  "type": "object",
+}
+`;
+
 exports[`typed-ajv Object() works with object schema and nullable option 1`] = `
 Object {
   "additionalProperties": false,

--- a/src/__tests__/index.test-d.ts
+++ b/src/__tests__/index.test-d.ts
@@ -58,6 +58,14 @@ expectError<{ p2: number }>(CS.Object({ p1: CS.Number(true) }, true).type);
 expectType<{ p1: number } & { p2?: boolean }>(
     CS.Object({ p1: CS.Number(true), p2: CS.Boolean(false) }, true).type,
 );
+expectType<{ a: string[] }>(
+    CS.Object(
+        {
+            a: CS.Array(CS.String(true), true),
+        },
+        true,
+    ).type,
+);
 
 // MergeObject
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -250,6 +250,22 @@ describe('typed-ajv', () => {
 
             expect(obj.getJsonSchema()).toMatchSnapshot();
         });
+
+        it('works with object schema and nested array', () => {
+            const obj = CS.Object(
+                {
+                    a: CS.Array(CS.String(true), true),
+                },
+                true,
+            );
+            type objType = typeof obj.type;
+
+            checkType<objType>({
+                a: ['a'],
+            });
+
+            expect(obj.getJsonSchema()).toMatchSnapshot();
+        });
     });
 
     describe('MergeObjects', () => {


### PR DESCRIPTION
This detects implicit conversion of options into `any` in the nullable case, weirdly enough this doesn't seem to happen with nested objects, go figure...