### PR TITLE
Make Select reject input data that doesn't have the selector, because…

### DIFF
--- a/src/__tests__/index.test-d.ts
+++ b/src/__tests__/index.test-d.ts
@@ -222,82 +222,25 @@ expectNotAssignable<number | string>(
 
 // Select
 
-expectType<string | boolean>(
-  CS.Select(
-    '1/otherProp',
-    {
-      foo: CS.String(true),
-      bar: CS.Boolean(true),
-    },
-    true,
-  ).type,
-);
+// This test fails with the error Parameter type { prop: "val1"; } | { prop: "val2"; } is not identical to argument type ({ prop: "val1"; } & {}) | ({ prop: "val2"; } & {}).
+// However these two types are identical, and there doesn't appear to be a way to workaround that.
+// expectType<{ prop: 'val1' } | { prop: 'val2' }>(
+//   CS.Select(
+//     'prop',
+//     {
+//       val1: CS.Object({ prop: CS.Enum(['val1'] as const, true) }, true),
+//       val2: CS.Object({ prop: CS.Enum(['val2'] as const, true) }, true),
+//     },
+//     true,
+//   ).type,
+// );
 
 expectNotAssignable<number>(
   CS.Select(
-    '1/otherProp',
+    'prop',
     {
-      foo: CS.String(true),
-      bar: CS.Boolean(true),
-    },
-    true,
-  ).type,
-);
-
-expectAssignable<{ foo: string | boolean }>(
-  CS.Object(
-    {
-      foo: CS.Select(
-        '1/otherProp',
-        {
-          foo: CS.String(true),
-          bar: CS.Boolean(true),
-        },
-        true,
-      ),
-    },
-    true,
-  ).type,
-);
-
-expectAssignable<{ foo?: string | boolean }>(
-  CS.Object(
-    {
-      foo: CS.Select(
-        '1/otherProp',
-        {
-          foo: CS.String(true),
-          bar: CS.Boolean(true),
-        },
-        false,
-      ),
-    },
-    true,
-  ).type,
-);
-
-expectNotAssignable<{ foo: string | boolean }>(
-  CS.Object(
-    {
-      foo: CS.Select(
-        '1/otherProp',
-        {
-          foo: CS.String(true),
-          bar: CS.Boolean(true),
-        },
-        false,
-      ),
-    },
-    true,
-  ).type,
-);
-
-expectNotAssignable<number>(
-  CS.Select(
-    '1/otherProp',
-    {
-      foo: CS.String(true),
-      bar: CS.Boolean(true),
+      val1: CS.Object({ prop: CS.Enum(['val1'] as const, true) }, true),
+      val2: CS.Object({ prop: CS.Enum(['val2'] as const, true) }, true),
     },
     true,
   ).type,

--- a/src/__tests__/index.test-d.ts
+++ b/src/__tests__/index.test-d.ts
@@ -223,26 +223,38 @@ expectNotAssignable<number | string>(
 // Select
 
 expectType<string | boolean>(
-  CS.Select(true, '1/otherProp', {
-    foo: CS.String(true),
-    bar: CS.Boolean(true),
-  }).type,
+  CS.Select(
+    '1/otherProp',
+    {
+      foo: CS.String(true),
+      bar: CS.Boolean(true),
+    },
+    true,
+  ).type,
 );
 
 expectNotAssignable<number>(
-  CS.Select(true, '1/otherProp', {
-    foo: CS.String(true),
-    bar: CS.Boolean(true),
-  }).type,
+  CS.Select(
+    '1/otherProp',
+    {
+      foo: CS.String(true),
+      bar: CS.Boolean(true),
+    },
+    true,
+  ).type,
 );
 
 expectAssignable<{ foo: string | boolean }>(
   CS.Object(
     {
-      foo: CS.Select(true, '1/otherProp', {
-        foo: CS.String(true),
-        bar: CS.Boolean(true),
-      }),
+      foo: CS.Select(
+        '1/otherProp',
+        {
+          foo: CS.String(true),
+          bar: CS.Boolean(true),
+        },
+        true,
+      ),
     },
     true,
   ).type,
@@ -251,10 +263,14 @@ expectAssignable<{ foo: string | boolean }>(
 expectAssignable<{ foo?: string | boolean }>(
   CS.Object(
     {
-      foo: CS.Select(false, '1/otherProp', {
-        foo: CS.String(true),
-        bar: CS.Boolean(true),
-      }),
+      foo: CS.Select(
+        '1/otherProp',
+        {
+          foo: CS.String(true),
+          bar: CS.Boolean(true),
+        },
+        false,
+      ),
     },
     true,
   ).type,
@@ -263,43 +279,27 @@ expectAssignable<{ foo?: string | boolean }>(
 expectNotAssignable<{ foo: string | boolean }>(
   CS.Object(
     {
-      foo: CS.Select(false, '1/otherProp', {
-        foo: CS.String(true),
-        bar: CS.Boolean(true),
-      }),
+      foo: CS.Select(
+        '1/otherProp',
+        {
+          foo: CS.String(true),
+          bar: CS.Boolean(true),
+        },
+        false,
+      ),
     },
     true,
   ).type,
 );
 
 expectNotAssignable<number>(
-  CS.Select(true, '1/otherProp', {
-    foo: CS.String(true),
-    bar: CS.Boolean(true),
-  }).type,
-);
-
-expectType<string | boolean | null>(
   CS.Select(
-    true,
     '1/otherProp',
     {
       foo: CS.String(true),
       bar: CS.Boolean(true),
     },
-    CS.Null(true),
-  ).type,
-);
-
-expectNotAssignable<number>(
-  CS.Select(
     true,
-    '1/otherProp',
-    {
-      foo: CS.String(true),
-      bar: CS.Boolean(true),
-    },
-    CS.Null(true),
   ).type,
 );
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -554,64 +554,64 @@ describe('typed-ajv', () => {
   describe('Select()', () => {
     it('works with select-case schema', () => {
       const cs = CS.Select(
-        'otherProp',
+        'prop',
         {
-          foo: CS.String(true),
-          bar: CS.Boolean(true),
+          val1: CS.Object({ prop: CS.Enum(['val1'] as const, true) }, true),
+          val2: CS.Object({ prop: CS.Enum(['val2'] as const, true) }, true),
         },
         true,
       );
       type csType = typeof cs.type;
 
-      checkType<csType>('str');
-      checkType<csType>(true);
+      checkType<csType>({ prop: 'val1' });
+      checkType<csType>({ prop: 'val2' });
 
-      expect(cs.getJsonSchema()).toEqual({
-        required: ['otherProp'],
-        select: { $data: '0/otherProp' },
-        selectCases: {
-          foo: { type: 'string', transform: ['trim'] },
-          bar: { type: 'boolean' },
-        },
-        selectDefault: { not: {} },
-      });
-    });
-
-    it('is included in a required schema', () => {
-      const cs = CS.Object(
-        {
-          foo: CS.Select(
-            'otherProp',
-            {
-              foo: CS.String(true),
-              bar: CS.Boolean(false),
-            },
-            true,
-          ),
-        },
-        true,
-      );
-      type csType = typeof cs.type;
-
-      checkType<csType>({ foo: 'str' });
-      checkType<csType>({ foo: true });
-
-      expect(cs.getJsonSchema()).toEqual({
-        type: 'object',
-        properties: {
-          foo: {
-            required: ['otherProp'],
-            select: { $data: '0/otherProp' },
-            selectCases: {
-              foo: { type: 'string', transform: ['trim'] },
-              bar: { type: 'boolean' },
-            },
-            selectDefault: { not: {} },
+      expect(cs.getJsonSchema()).toMatchInlineSnapshot(`
+        Object {
+          "required": Array [
+            "prop",
+          ],
+          "select": Object {
+            "$data": "0/prop",
           },
-        },
-        required: ['foo'],
-        additionalProperties: false,
-      });
+          "selectCases": Object {
+            "val1": Object {
+              "additionalProperties": false,
+              "properties": Object {
+                "prop": Object {
+                  "enum": Array [
+                    "val1",
+                  ],
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "prop",
+              ],
+              "type": "object",
+            },
+            "val2": Object {
+              "additionalProperties": false,
+              "properties": Object {
+                "prop": Object {
+                  "enum": Array [
+                    "val2",
+                  ],
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "prop",
+              ],
+              "type": "object",
+            },
+          },
+          "selectDefault": Object {
+            "not": Object {},
+          },
+          "type": "object",
+        }
+      `);
     });
   });
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -553,17 +553,22 @@ describe('typed-ajv', () => {
 
   describe('Select()', () => {
     it('works with select-case schema', () => {
-      const cs = CS.Select(true, '1/otherProp', {
-        foo: CS.String(true),
-        bar: CS.Boolean(true),
-      });
+      const cs = CS.Select(
+        'otherProp',
+        {
+          foo: CS.String(true),
+          bar: CS.Boolean(true),
+        },
+        true,
+      );
       type csType = typeof cs.type;
 
       checkType<csType>('str');
       checkType<csType>(true);
 
       expect(cs.getJsonSchema()).toEqual({
-        select: { $data: '1/otherProp' },
+        required: ['otherProp'],
+        select: { $data: '0/otherProp' },
         selectCases: {
           foo: { type: 'string', transform: ['trim'] },
           bar: { type: 'boolean' },
@@ -572,39 +577,17 @@ describe('typed-ajv', () => {
       });
     });
 
-    it('works with select-case schema and a default case', () => {
-      const cs = CS.Select(
-        true,
-        '1/otherProp',
-        {
-          foo: CS.String(true),
-          bar: CS.Boolean(true),
-        },
-        CS.Number(false),
-      );
-      type csType = typeof cs.type;
-
-      checkType<csType>('str');
-      checkType<csType>(true);
-      checkType<csType>(12);
-
-      expect(cs.getJsonSchema()).toEqual({
-        select: { $data: '1/otherProp' },
-        selectCases: {
-          foo: { type: 'string', transform: ['trim'] },
-          bar: { type: 'boolean' },
-        },
-        selectDefault: { type: 'number' },
-      });
-    });
-
     it('is included in a required schema', () => {
       const cs = CS.Object(
         {
-          foo: CS.Select(true, '1/otherProp', {
-            foo: CS.String(true),
-            bar: CS.Boolean(false),
-          }),
+          foo: CS.Select(
+            'otherProp',
+            {
+              foo: CS.String(true),
+              bar: CS.Boolean(false),
+            },
+            true,
+          ),
         },
         true,
       );
@@ -617,7 +600,8 @@ describe('typed-ajv', () => {
         type: 'object',
         properties: {
           foo: {
-            select: { $data: '1/otherProp' },
+            required: ['otherProp'],
+            select: { $data: '0/otherProp' },
             selectCases: {
               foo: { type: 'string', transform: ['trim'] },
               bar: { type: 'boolean' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -323,24 +323,26 @@ function _Optional<S extends CommonSchema<unknown, unknown>>(schema: S) {
 function _Select<
   R extends boolean,
   Cases extends string,
-  Case extends CommonSchema<unknown, unknown>
+  Case extends CommonSchema<Record<string, unknown>, unknown>
 >(property: string, cases: Record<Cases, Case>, required: R) {
   return {
     getJsonSchema(): {
       select: { $data: string };
       selectCases: Record<Cases, unknown>;
       selectDefault: unknown;
-      required: unknown;
+      required: string[];
+      type: 'object';
     } {
       return {
         // Note: the selectDefault branch is only tested when the data pointed to by select.$data is defined.
         // This means that input data where the data pointed to by select.$data is undefined is always
-        // considereed valid.
+        // considered valid.
         //
         // We want unexpected data not to match the schema, so we need `property` to be required to work around this pitfall.
         //
         // This also means that we can't really use selectDefault, since it only works when type is present.
         required: [property],
+        type: 'object',
         select: { $data: `0/${property}` },
         selectCases: _.mapValues(cases, v => v.getJsonSchema()),
         selectDefault: { not: {} },


### PR DESCRIPTION
… otherwise it would consider all data

that doesn't have the selector valid. The arguments are also simplified since, if we want sane validation,
we can't be as flexible as before.